### PR TITLE
Fixed spec

### DIFF
--- a/spec/features/image_feature_spec.rb
+++ b/spec/features/image_feature_spec.rb
@@ -9,13 +9,12 @@ feature 'images' do
 
   scenario 'are created when route receives image url' do
     expect(Image.all.count).to eq 0
-    # request.env['HTTP_ACCEPT'] = 'application/vnd.api+json'
-    # request.env['CONTENT_TYPE'] = 'application/vnd.api+json'
-    # request.accept = "application/vnd.api+json"
-    # post :create, { "data": { "type": "images", "attributes": {"image_url": "http://www.example.com/images/image.jpg" } } }
-    # post "/images", { "data" => { "type" => "images", "image_url" => "http://www.example.com/images/image.jpg" } }
-    # post "/images", {format: :"json+api", "data" => { "type" => "images", "image_url" => "http://www.example.com/images/image.jpg" } }, {"CONTENT_TYPE" => "application/vnd.api+json"}
-    # expect(JSON.parse(last_response.body)).to eq({ not_sure: "what" })
+    post "/images", { "data" => { "type" => "images", "attributes" => { "image-url" => "http://www.example.com/images/image.jpg" } } }.to_json, { "CONTENT_TYPE" => "application/vnd.api+json" }
+    result = JSON.parse(last_response.body)["data"]
+    expect(result["id"].to_i).to be > 0
+    expect(result["type"]).to eq "images"
+    expect(result["links"]["self"]).to start_with "http://example.org/images/"
+    expect(result["attributes"]).to eq({ "image-url"=>"http://www.example.com/images/image.jpg" })
     expect(Image.all.count).to eq 1
   end
 


### PR DESCRIPTION
Hey Sara,

I had to do the following:
1. Convert the hash to a json-encoded string (`.to_json`)
2. Change the attribute `"image_url"` to `"image-url"` because jsonapi-resources expects attribute names to be dasherized ¯_(ツ)_/¯

You were almost there. :-)
